### PR TITLE
Add "decord" to requirements.txt

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -18,3 +18,4 @@ pyloudnorm
 optimum-quanto==0.2.6
 scenedetect
 moviepy==1.0.3
+decord


### PR DESCRIPTION
Add "decord" to requirements.txt to solve "ModuleNotFoundError: No module named 'decord'"