### PR TITLE
fix: replace 4 bare except clauses with except Exception

### DIFF
--- a/kokoro/model.py
+++ b/kokoro/model.py
@@ -67,13 +67,13 @@ class KModel(torch.nn.Module):
         if not model:
             try:
                 model = hf_hub_download(repo_id=repo_id, filename=KModel.MODEL_NAMES[repo_id])
-            except:
+            except Exception:
                 model = os.path.join(repo_id, 'kokoro-v1_0.pth')
         for key, state_dict in torch.load(model, map_location='cpu', weights_only=True).items():
             assert hasattr(self, key), key
             try:
                 getattr(self, key).load_state_dict(state_dict)
-            except:
+            except Exception:
                 logger.debug(f"Did not load {key} from state_dict")
                 state_dict = {k[7:]: v for k, v in state_dict.items()}
                 getattr(self, key).load_state_dict(state_dict, strict=False)

--- a/wan/modules/multitalk_model.py
+++ b/wan/modules/multitalk_model.py
@@ -18,7 +18,7 @@ try:
     from sageattention import sageattn
     USE_SAGEATTN = True
     logging.info("Using sageattn")
-except:
+except Exception:
     USE_SAGEATTN = False
 
 __all__ = ['WanModel']

--- a/wan/utils/prompt_extend.py
+++ b/wan/utils/prompt_extend.py
@@ -402,7 +402,7 @@ class QwenPromptExpander(PromptExpander):
             )
             try:
                 from .qwen_vl_utils import process_vision_info
-            except:
+            except Exception:
                 from qwen_vl_utils import process_vision_info
             self.process_vision_info = process_vision_info
             min_pixels = 256 * 28 * 28


### PR DESCRIPTION
## What
Replace 4 bare `except:` clauses with `except Exception:`.

## Why
Bare `except:` catches `BaseException`, including `KeyboardInterrupt` and `SystemExit`, which can prevent clean process shutdown and mask critical errors. Using `except Exception:` catches all application-level errors while allowing system-level exceptions to propagate correctly.